### PR TITLE
Fix sidebar list and buttons

### DIFF
--- a/src/app/feed/feed.page.html
+++ b/src/app/feed/feed.page.html
@@ -20,11 +20,6 @@
               <ion-label>{{source.title}}</ion-label>
             }            
           </ion-item>
-          <ion-item-options side="end">
-            <ion-item-option color="danger">
-              <ion-icon slot="icon-only" name="trash" (click)="sourcesService.removeSource(source.url)"></ion-icon>
-            </ion-item-option>
-          </ion-item-options>
         </ion-item-sliding>
       }
     </ion-list>

--- a/src/app/feed/feed.page.html
+++ b/src/app/feed/feed.page.html
@@ -12,15 +12,13 @@
     <ion-list>
       @for (source of sourcesService.getSources(); track source.url) {
         <ion-item-sliding>
-          <ion-item (click)="filterByUrl(source.url)">
+          <ion-item button (click)="filterByUrl(source.url)">
             @if (source.url === filter) {
-              <ion-icon aria-hidden="true" name="chevron-forward" slot="start"></ion-icon>
+              <ion-label color="secondary">{{source.title}}</ion-label>
             }
-            <ion-label>
-              <strong>{{source.title}}</strong>
-              <br />
-              <ion-text>{{source.url}}</ion-text>
-            </ion-label>
+            @else {
+              <ion-label>{{source.title}}</ion-label>
+            }            
           </ion-item>
           <ion-item-options side="end">
             <ion-item-option color="danger">

--- a/src/app/feed/feed.page.html
+++ b/src/app/feed/feed.page.html
@@ -11,16 +11,14 @@
     <br />
     <ion-list>
       @for (source of sourcesService.getSources(); track source.url) {
-        <ion-item-sliding>
-          <ion-item button (click)="filterByUrl(source.url)">
-            @if (source.url === filter) {
-              <ion-label color="secondary">{{source.title}}</ion-label>
-            }
-            @else {
-              <ion-label>{{source.title}}</ion-label>
-            }            
-          </ion-item>
-        </ion-item-sliding>
+        <ion-item button (click)="filterByUrl(source.url)">
+          @if (source.url === filter) {
+            <ion-label color="secondary">{{source.title}}</ion-label>
+          }
+          @else {
+            <ion-label>{{source.title}}</ion-label>
+          }            
+        </ion-item>
       }
     </ion-list>
     <br />
@@ -117,28 +115,26 @@
               }
               @if (settingsService.getSettings().compressedFeed) {
                 <div>
-                  <ion-item-sliding>
-                    <ion-item [button]="true" (click)="openPreview(entry.title, entry.content, entry.link)">
-                      @if (settingsService.getSettings().showImages) {
-                        <div>
-                          @if (entry.imgLink !== null) {
-                            <ion-thumbnail slot="start">
-                              <img alt="Entry Cover Image" src="{{ entry.imgLink }}" />
-                            </ion-thumbnail>
-                          }
-                        </div>
-                      }
-                      <ion-label>
-                        <strong>{{entry.title}}</strong><br />
-                        <ion-text>{{entry.source}}</ion-text><br />
-                        <ion-note color="medium" class="ion-text-wrap">{{entry.contentStripped}}</ion-note>
-                      </ion-label>
-                      <div class="metadata-end-wrapper" slot="end">
-                        <ion-note color="medium">{{formatDateAsDay(entry.isoDate, settingsService.getSettings().locale)}}</ion-note>
-                        <!-- <ion-icon color="medium" name="chevron-forward"></ion-icon> -->
+                  <ion-item [button]="true" (click)="openPreview(entry.title, entry.content, entry.link)">
+                    @if (settingsService.getSettings().showImages) {
+                      <div>
+                        @if (entry.imgLink !== null) {
+                          <ion-thumbnail slot="start">
+                            <img alt="Entry Cover Image" src="{{ entry.imgLink }}" />
+                          </ion-thumbnail>
+                        }
                       </div>
-                    </ion-item>
-                  </ion-item-sliding>
+                    }
+                    <ion-label>
+                      <strong>{{entry.title}}</strong><br />
+                      <ion-text>{{entry.source}}</ion-text><br />
+                      <ion-note color="medium" class="ion-text-wrap">{{entry.contentStripped}}</ion-note>
+                    </ion-label>
+                    <div class="metadata-end-wrapper" slot="end">
+                      <ion-note color="medium">{{formatDateAsDay(entry.isoDate, settingsService.getSettings().locale)}}</ion-note>
+                      <!-- <ion-icon color="medium" name="chevron-forward"></ion-icon> -->
+                    </div>
+                  </ion-item>
                 </div>
               }
             </div>

--- a/src/app/feed/feed.page.ts
+++ b/src/app/feed/feed.page.ts
@@ -11,7 +11,6 @@ import {
   IonFab, IonFabButton,
   IonHeader, IonIcon, IonInput, IonItem,
   IonItemOption, IonItemOptions,
-  IonItemSliding,
   IonLabel, IonList,
   IonMenu,
   IonMenuToggle,
@@ -23,7 +22,7 @@ import {
   ScrollDetail
 } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
-import { bookmark, bookmarkOutline, chevronForward, chevronUpOutline, ellipsisVertical, filterOutline, shareSocialOutline, trash } from 'ionicons/icons';
+import { bookmark, bookmarkOutline, chevronForward, chevronUpOutline, ellipsisVertical, filterOutline, shareSocialOutline } from 'ionicons/icons';
 import { PreviewComponent } from '../preview/preview.component';
 import { BookmarkService } from '../services/bookmark.service';
 import { FeedService } from '../services/feed.service';
@@ -41,7 +40,7 @@ import { SettingsComponent } from '../settings/settings.component';
     IonCardSubtitle, IonCardTitle, IonHeader, IonToolbar, IonTitle, IonNote, 
     IonContent, IonList, IonInput, IonItem, IonItemOption, IonItemOptions, 
     IonIcon, IonButton, IonButtons, IonText, IonMenu, IonThumbnail, IonMenuToggle, 
-    IonItemSliding, IonLabel, IonRefresher, IonRefresherContent, IonFab, IonFabButton,
+    IonLabel, IonRefresher, IonRefresherContent, IonFab, IonFabButton,
     SettingsComponent]
 })
 
@@ -57,7 +56,7 @@ export class FeedPage {
               private modalController: ModalController, public elementRef: ElementRef,
               public settingsService: SettingsService) {
     addIcons({ bookmark, bookmarkOutline, shareSocialOutline, ellipsisVertical, filterOutline, chevronForward, 
-      chevronUpOutline, trash });
+      chevronUpOutline });
   }
 
   public formatDate(dateStr: string | number, locale: string) {


### PR DESCRIPTION
This PR resolves the debounce issue on the sidebar and fixes #28. 

It also clears up the display of menu items. 
- Now that sources have good metadata automatically added to them the URL can be removed. 
- Removes the optional buttons making it easier to swipe away the menu and prevents sources being accidentally deleted.
- Selected items will now be coloured differently rather than adding a second chevron