### PR TITLE
Concurrently pull feed updates

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "importHelpers": true,
     "target": "es2022",
     "module": "es2020",
-    "lib": ["es2018", "dom"],
+    "lib": ["es2019", "dom"],
     "useDefineForClassFields": false
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
This significantly speeds up refreshing when multiple sources are defined. The app will no longer wait for each source to finish downloading to start the next, it will instead send all the requests at the same time and wait for them all to return.